### PR TITLE
chore: simplify the error message

### DIFF
--- a/eventastic/src/aggregate/root.rs
+++ b/eventastic/src/aggregate/root.rs
@@ -342,7 +342,7 @@ where
 
     /// This error is returned when the Repository fails to insert the event
     /// because the version already exists, indicating a concurrent modification.
-    #[error("Optimistic Concurrency Error Version {1} of aggregate {0:?} already exists")]
+    #[error("Optimistic Concurrency Error")]
     OptimisticConcurrency(T::AggregateId, u64),
 }
 


### PR DESCRIPTION
When we get this error logged we end up with lots of different messages due to the aggregate ID and version number. These should be logged outside of the message to make grouping this easier.